### PR TITLE
Only load dependency modules if not already loaded.

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -100,8 +100,8 @@ ENV LD_LIBRARY_PATH=$LD_LIBRARY_PATH:${NVIDIA_LIB_PATH}
 
 VOLUME ${NVIDIA_PATH}
 
-CMD insmod `find /rootfs/usr -iname ipmi_msghandler.ko` && \
-    insmod `find /rootfs/usr -iname ipmi_devintf.ko` && \
+CMD if ! lsmod | grep "ipmi_msghandler" &> /dev/null; then insmod `find /rootfs/usr -iname ipmi_msghandler.ko`; fi \
+    if ! lsmod | grep "ipmi_devintf" &> /dev/null; then insmod `find /rootfs/usr -iname ipmi_devintf.ko`; fi && \
     insmod ${NVIDIA_MODULES_PATH}/nvidia.ko && \
     insmod ${NVIDIA_MODULES_PATH}/nvidia-uvm.ko && \
     nvidia-mkdevs


### PR DESCRIPTION
Added checks to only load the dependency modules if they are not already loaded.
Therefore fixes https://github.com/src-d/coreos-nvidia/issues/4.