### PR TITLE
Fixed issue with alpha branch by installing additional dependency.

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -2,7 +2,7 @@ FROM ubuntu:17.10 as BUILD
 MAINTAINER source{d}
 
 RUN apt-get -y update && \
-    apt-get -y install curl git bc make dpkg-dev libssl-dev module-init-tools p7zip-full libelf-dev && \
+    apt-get -y install curl git bc make dpkg-dev libssl-dev module-init-tools p7zip-full libelf-dev flex bison && \
     apt-get autoremove && \
     apt-get clean
 


### PR DESCRIPTION
The alpha branch pipeline is failing because a dependency is missing.